### PR TITLE
Fix memory persistence initialization bug

### DIFF
--- a/memory/session_memory.py
+++ b/memory/session_memory.py
@@ -5,11 +5,15 @@ from collections import defaultdict
 class MemoryStore:
     def __init__(self, path="logs/user_memory.json"):
         self.path = path
+        # Ensure the directory exists before any reads/writes
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
         if os.path.exists(path):
             with open(path, "r") as f:
                 self.store = json.load(f)
         else:
             self.store = defaultdict(dict)
+            # Persist initial empty store so future reads succeed
+            self._save()
 
     def get(self, user_id: str) -> dict:
         return self.store.get(user_id, {})
@@ -18,8 +22,7 @@ class MemoryStore:
         if user_id not in self.store:
             self.store[user_id] = {}
         self.store[user_id][key] = value
-        with open(self.path, "w") as f:
-            json.dump(self.store, f, indent=2)
+        self._save()
 
     def update(self, user_id: str, key: str, value: str):
         if user_id not in self.store:


### PR DESCRIPTION
## Summary
- ensure logs directory exists before writing memory
- save initial empty store and use `_save()` in `set`

## Testing
- `python -m py_compile memory/session_memory.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f151a2cc83328e4546d31a69fb6b